### PR TITLE
Patch for adding aw-qt.desktop file to /etc/xdg/autostart and deduplicate libraries

### DIFF
--- a/debian-package.sh
+++ b/debian-package.sh
@@ -4,10 +4,13 @@ set -e
 
 # Following this: http://www.sj-vs.net/creating-a-simple-debian-deb-package-based-on-a-directory-structure/
 
-VERSION_NUM="0.8.0b2"
+VERSION_NUM="0.9.2"
 VERSION="v$VERSION_NUM"
 URL="https://github.com/ActivityWatch/activitywatch/releases/download/${VERSION}/activitywatch-${VERSION}-linux-x86_64.zip"
 PKGDIR="activitywatch_$VERSION_NUM"
+
+#install tools needed for packaging
+sudo apt-get install sed jdupes wget
 
 # Prerun cleanup
 if [ -d "$PKGDIR" ]; then
@@ -18,6 +21,7 @@ fi
 # Create directories
 mkdir -p $PKGDIR/DEBIAN
 mkdir -p $PKGDIR/opt
+mkdir -p $PKGDIR/etc/xdg/autostart
 
 # Move template files into DEBIAN
 cp activitywatch_template/DEBIAN/* $PKGDIR/DEBIAN
@@ -25,9 +29,16 @@ sudo sed -i "s/Version: .*/Version: $VERSION_NUM/g" $PKGDIR/DEBIAN/control
 
 # Get and unzip binary
 wget --continue -O activitywatch-$VERSION-linux.zip $URL
-unzip activitywatch-$VERSION-linux.zip -d $PKGDIR/opt/
+unzip -q activitywatch-$VERSION-linux.zip -d $PKGDIR/opt/
+
+# Hard link duplicated libraries
+jdupes -L -r -S -Xsize-:1K $PKGDIR/opt/
 
 # Set file permissions
 sudo chown -R root:root $PKGDIR
+
+#setup autostart file
+sudo sed -i 's!Exec=aw-qt!Exec=/opt/activitywatch/aw-qt!' $PKGDIR/opt/activitywatch/aw-qt.desktop
+sudo cp $PKGDIR/opt/activitywatch/aw-qt.desktop $PKGDIR/etc/xdg/autostart
 
 dpkg-deb --build $PKGDIR


### PR DESCRIPTION
I've noticed, that there are ~400 duplicated files, mainly python and other .so files (libraries) in activitywatch 0.9.2 x86_64.zip release for Linux, see attached 
[activitywatch_0.9.2-duplicates.txt](https://github.com/ActivityWatch/deb-activitywatch-bin/files/4629299/activitywatch_0.9.2-duplicates.txt)

So, I decreased .deb package size by ~25MB by hard linking duplicated libraries with jdupes tool and also added aw-qt.desktop file to /etc/xdg/autostart :)