### PR TITLE
Improves package build 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-package:
-	bash debian-package.sh
+VERSION ?= "0.11.0"
+
+build:
+	bash debian-package.sh $(VERSION)
 
 clean:
-	rm *.zip
-	sudo rm -r activitywatch_v*
-	sudo rm -r activitywatch_0*
+	rm -r activitywatch_v* activitywatch_0* *.zip 2> /dev/null

--- a/debian-package.sh
+++ b/debian-package.sh
@@ -4,17 +4,17 @@ set -e
 
 # Following this: http://www.sj-vs.net/creating-a-simple-debian-deb-package-based-on-a-directory-structure/
 
-VERSION_NUM="0.9.2"
+[ -z $1 ] && VERSION_NUM="0.9.2" || VERSION_NUM=$1
 VERSION="v$VERSION_NUM"
 URL="https://github.com/ActivityWatch/activitywatch/releases/download/${VERSION}/activitywatch-${VERSION}-linux-x86_64.zip"
 PKGDIR="activitywatch_$VERSION_NUM"
 
 #install tools needed for packaging
-sudo apt-get install sed jdupes wget
+# sudo apt-get install sed jdupes wget
 
 # Prerun cleanup
 if [ -d "$PKGDIR" ]; then
-    sudo chown -R $USER $PKGDIR
+    chown -R $USER $PKGDIR
     rm -rf $PKGDIR
 fi
 
@@ -25,7 +25,7 @@ mkdir -p $PKGDIR/etc/xdg/autostart
 
 # Move template files into DEBIAN
 cp activitywatch_template/DEBIAN/* $PKGDIR/DEBIAN
-sudo sed -i "s/Version: .*/Version: $VERSION_NUM/g" $PKGDIR/DEBIAN/control
+sed -i "s/Version: .*/Version: $VERSION_NUM/g" $PKGDIR/DEBIAN/control
 
 # Get and unzip binary
 wget --continue -O activitywatch-$VERSION-linux.zip $URL
@@ -34,11 +34,8 @@ unzip -q activitywatch-$VERSION-linux.zip -d $PKGDIR/opt/
 # Hard link duplicated libraries
 jdupes -L -r -S -Xsize-:1K $PKGDIR/opt/
 
-# Set file permissions
-sudo chown -R root:root $PKGDIR
-
 #setup autostart file
-sudo sed -i 's!Exec=aw-qt!Exec=/opt/activitywatch/aw-qt!' $PKGDIR/opt/activitywatch/aw-qt.desktop
-sudo cp $PKGDIR/opt/activitywatch/aw-qt.desktop $PKGDIR/etc/xdg/autostart
+sed -i 's!Exec=aw-qt!Exec=/opt/activitywatch/aw-qt!' $PKGDIR/opt/activitywatch/aw-qt.desktop
+cp $PKGDIR/opt/activitywatch/aw-qt.desktop $PKGDIR/etc/xdg/autostart
 
 dpkg-deb --build $PKGDIR


### PR DESCRIPTION
This patch hopes to improve package building from Makefile and script (```debian-package.sh```). I added a version parameter (```VERSION```) in the Makefile, so it's easier to "version" the package to be built.

It also removes the "sudo" commands from the script, simplifying and allowing manual calling of the command with "make" (example: ``sudo make build``)